### PR TITLE
Add tests for start/help commands and keyboards

### DIFF
--- a/test_help_command.py
+++ b/test_help_command.py
@@ -1,0 +1,23 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import main_bot_railway
+
+
+@pytest.mark.asyncio
+async def test_help_command_sends_help_text(monkeypatch):
+    """help_command should reply with help information."""
+    monkeypatch.setattr(main_bot_railway, "update_stats", lambda *a, **k: None)
+
+    mock_reply = AsyncMock()
+    message = SimpleNamespace(reply_text=mock_reply)
+    user = SimpleNamespace(id=1)
+    update = SimpleNamespace(message=message, effective_user=user)
+    context = SimpleNamespace()
+
+    await main_bot_railway.help_command(update, context)
+
+    mock_reply.assert_awaited_once()
+    sent_text = mock_reply.call_args[0][0]
+    assert "Справка по боту" in sent_text

--- a/test_reply_keyboards.py
+++ b/test_reply_keyboards.py
@@ -1,0 +1,15 @@
+from telegram import InlineKeyboardMarkup
+
+from utils.keyboards import create_main_menu_keyboard
+
+
+def test_create_main_menu_keyboard_structure():
+    """create_main_menu_keyboard should build the expected keyboard."""
+    keyboard = create_main_menu_keyboard()
+
+    assert isinstance(keyboard, InlineKeyboardMarkup)
+    # Expect three rows: two categories rows + one for relationships
+    assert len(keyboard.inline_keyboard) == 3
+    first_row = keyboard.inline_keyboard[0]
+    assert first_row[0].callback_data == "category_motivation"
+    assert first_row[1].callback_data == "category_esoteric"

--- a/test_start_command.py
+++ b/test_start_command.py
@@ -1,0 +1,22 @@
+import pytest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import main_bot_railway
+
+
+@pytest.mark.asyncio
+async def test_start_command_shows_main_menu(monkeypatch):
+    """start_command should call show_main_menu for valid updates."""
+    mock_show_main_menu = AsyncMock()
+    monkeypatch.setattr(main_bot_railway, "show_main_menu", mock_show_main_menu)
+    monkeypatch.setattr(main_bot_railway, "update_stats", lambda *a, **k: None)
+
+    user = SimpleNamespace(id=1, first_name="Tester", username="tester")
+    message = SimpleNamespace(reply_text=AsyncMock())
+    update = SimpleNamespace(message=message, effective_user=user)
+    context = SimpleNamespace()
+
+    await main_bot_railway.start_command(update, context)
+
+    mock_show_main_menu.assert_awaited_once_with(update, context)


### PR DESCRIPTION
## Summary
- add coverage for `/start` and `/help` commands
- verify main menu keyboard structure

## Testing
- `pre-commit run --files test_start_command.py test_help_command.py test_reply_keyboards.py` *(fails: InvalidConfigError: Expected a Config map but got a NoneType)*
- `pytest test_help_command.py test_start_command.py test_reply_keyboards.py -q`
- `pytest tests/ -q`

------
https://chatgpt.com/codex/tasks/task_e_68922c94a8048321ade2f58f35f148e3