### PR TITLE
Add About and Settings callbacks to main menu

### DIFF
--- a/main_bot_railway.py
+++ b/main_bot_railway.py
@@ -332,6 +332,16 @@ async def handle_callback_query(update: Update, context: ContextTypes.DEFAULT_TY
 🤝 **Рабочие отношения** - профессиональное общение
 """
                 keyboard = create_relationships_submenu()
+            elif category == "about":
+                await query.answer()
+                update.message = query.message
+                await about_command(update, context)
+                return
+            elif category == "settings":
+                await query.answer()
+                update.message = query.message
+                await settings_command(update, context)
+                return
             else:
                 await query.answer(f"📂 Категория: {category}\n🚧 В разработке!", show_alert=True)
                 return
@@ -804,8 +814,10 @@ def main():
         application.add_handler(CommandHandler("restart", restart_command))
         application.add_handler(CommandHandler("broadcast", broadcast_command))
         application.add_handler(CommandHandler("cleanup", cleanup_command))
-        
+
         # Обработчики callback и ошибок
+        application.add_handler(CallbackQueryHandler(handle_callback_query, pattern="^category_about$"))
+        application.add_handler(CallbackQueryHandler(handle_callback_query, pattern="^category_settings$"))
         application.add_handler(CallbackQueryHandler(handle_callback_query))
         application.add_error_handler(error_handler)
         
@@ -880,6 +892,8 @@ def run_local_polling():
     application.add_handler(CommandHandler("help", help_command))
     application.add_handler(CommandHandler("instructions", instructions_command))
     application.add_handler(CommandHandler("test", test_command))
+    application.add_handler(CallbackQueryHandler(handle_callback_query, pattern="^category_about$"))
+    application.add_handler(CallbackQueryHandler(handle_callback_query, pattern="^category_settings$"))
     application.add_handler(CallbackQueryHandler(handle_callback_query))
     application.add_error_handler(error_handler)
     

--- a/test_keyboards_complete.py
+++ b/test_keyboards_complete.py
@@ -17,8 +17,11 @@ class TestKeyboards(unittest.TestCase):
         """Тест главного меню"""
         keyboard = create_main_menu_keyboard()
         self.assertIsInstance(keyboard, InlineKeyboardMarkup)
-        self.assertEqual(len(keyboard.inline_keyboard), 3)
+        self.assertEqual(len(keyboard.inline_keyboard), 4)
         self.assertEqual(len(keyboard.inline_keyboard[0]), 2)
+        self.assertEqual(len(keyboard.inline_keyboard[3]), 2)
+        self.assertEqual(keyboard.inline_keyboard[3][0].callback_data, "category_about")
+        self.assertEqual(keyboard.inline_keyboard[3][1].callback_data, "category_settings")
         print("✅ Главное меню: OK")
 
     def test_create_submenu_keyboard(self):

--- a/utils/keyboards.py
+++ b/utils/keyboards.py
@@ -15,6 +15,10 @@ def create_main_menu_keyboard():
         ],
         [
             InlineKeyboardButton("💝 Отношения", callback_data="category_relationships")
+        ],
+        [
+            InlineKeyboardButton("ℹ️ О боте", callback_data="category_about"),
+            InlineKeyboardButton("⚙️ Настройки", callback_data="category_settings")
         ]
     ]
     return InlineKeyboardMarkup(keyboard)


### PR DESCRIPTION
## Summary
- extend main menu keyboard with About bot and Settings buttons
- handle category_about and category_settings in callback dispatcher
- register new callback handlers and update keyboard tests

## Testing
- `pytest test_keyboards_complete.py -q`
- `pytest -q` *(fails: async def functions are not natively supported)*

------
https://chatgpt.com/codex/tasks/task_e_689252e90fe483219f529d0c156d5de0