### PR TITLE
Configure pytest for async tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[tool.pytest.ini_options]
+# Enable automatic event loop handling for async tests
+asyncio_mode = "auto"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 python-telegram-bot[webhooks]>=21.0
 python-dotenv>=1.0.0
 psutil>=5.9.0
+pytest-asyncio>=0.20


### PR DESCRIPTION
## Summary
- enable asyncio support in pytest configuration
- add pytest-asyncio dependency for test execution

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689261e8a67c8321914f39e852f2f6e8