### PR TITLE
Clear webhook before polling and note single-instance requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ To start the bot, run:
 python main_bot.py
 ```
 
+> **Note**: Run only one instance of the bot in polling mode at a time. 
+> Running multiple polling processes simultaneously can lead to
+> duplicate update handling and unexpected behavior.
+
 ## Available Commands
 
 - `/start` - Welcome message and command list

--- a/main_bot.py
+++ b/main_bot.py
@@ -7,6 +7,7 @@ Telegram Bot для публикации постов в канал
 # --- Импорты ---
 import os
 import logging
+import asyncio
 from dotenv import load_dotenv
 from telegram import (
     Update, ReplyKeyboardMarkup, InlineKeyboardMarkup, InlineKeyboardButton
@@ -740,4 +741,5 @@ if __name__ == '__main__':
     )
 
     print("Бот запущен. Ожидание сообщений... (Ctrl+C для остановки)")
+    asyncio.run(app.bot.delete_webhook(drop_pending_updates=True))
     app.run_polling()

--- a/main_bot_railway.py
+++ b/main_bot_railway.py
@@ -1,6 +1,7 @@
 # main_bot_railway.py - Минимальная версия с базовым меню
 import logging
 import os
+import asyncio
 from typing import Optional
 from telegram import Update, InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.ext import (
@@ -899,6 +900,7 @@ def run_local_polling():
         await setup_bot_commands(application)
     
     application.post_init = post_init
+    asyncio.run(application.bot.delete_webhook(drop_pending_updates=True))
     application.run_polling(drop_pending_updates=True)
 
 if __name__ == '__main__':

--- a/main_bot_railway_backup.py
+++ b/main_bot_railway_backup.py
@@ -1068,8 +1068,9 @@ def run_local_polling():
     application.add_handler(CallbackQueryHandler(handle_callback_query))
     application.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_text_message))
     application.add_error_handler(error_handler)
-    
+
     logger.info("🔄 Запуск polling режима...")
+    asyncio.run(application.bot.delete_webhook(drop_pending_updates=True))
     application.run_polling(drop_pending_updates=True)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- call `delete_webhook(drop_pending_updates=True)` before polling to prevent processing stale updates
- document that only one bot instance should poll at a time to avoid duplicate processing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892721c04e0832188a95283b5c540a7