### PR TITLE
Use logging and mask token in config

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,9 +1,12 @@
 # config.py - Конфигурация бота
 import os
+import logging
 from dotenv import load_dotenv
 
 # Загружаем переменные окружения
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 # Токен бота
 BOT_TOKEN = os.getenv('BOT_TOKEN')
@@ -45,6 +48,7 @@ def validate_config():
     if not ADMIN_ID:
         raise ValueError("ADMIN_ID не найден в переменных окружения")
     
-    print(f"✅ Конфигурация загружена успешно")
-    print(f"🤖 Токен бота: {BOT_TOKEN[:10]}...{BOT_TOKEN[-10:]}")
-    print(f"👤 ID администратора: {ADMIN_ID}")
+    logger.info("✅ Конфигурация загружена успешно")
+    masked_token = BOT_TOKEN if len(BOT_TOKEN) <= 8 else f"{BOT_TOKEN[:4]}...{BOT_TOKEN[-4:]}"
+    logger.info(f"🤖 Токен бота: {masked_token}")
+    logger.info(f"👤 ID администратора: {ADMIN_ID}")


### PR DESCRIPTION
## Summary
- replace print diagnostics with `logging` in `config.py`
- mask bot token before output

## Testing
- `pytest` *(fails: async def functions are not natively supported)*
- `pre-commit run --files config.py` *(fails: InvalidConfigError: Expected a Config map but got a NoneType)*

------
https://chatgpt.com/codex/tasks/task_e_68909b4a90188321880db1f142d9389a