### PR TITLE
Add missing requests and benchmark dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,12 +3,13 @@ python-dotenv>=1.0.0
 psutil>=5.9.0
 openai>=1.0.0
 flask>=2.3.0
+requests>=2.31.0
 
 # Development and testing dependencies (optional, installed in CI)
 pytest>=7.0.0
 pytest-cov>=4.0.0
 pytest-asyncio>=0.21.0
-# pytest-benchmark>=4.0.0
+pytest-benchmark>=4.0.0
 # black>=23.0.0
 # isort>=5.12.0
 # flake8>=6.0.0


### PR DESCRIPTION
## Summary
- add requests to requirements for HTTP tests
- enable pytest-benchmark to provide benchmark fixture

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68931afdffa8832185a7a5ac5c67dc2d